### PR TITLE
Fixed user roles

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -16,7 +16,13 @@ class MerchantsController < ApplicationController
   end
 
   # GET /merchants/1/edit
-  def edit; end
+  def edit
+    if current_user.role_admin?
+      @merchant = Merchant.find_by_id(params[:id])
+    else
+      redirect_to @merchant, alert: 'Admin not authrized'
+    end
+  end
 
   # POST /merchants or /merchants.json
   def create
@@ -48,11 +54,15 @@ class MerchantsController < ApplicationController
 
   # DELETE /merchants/1 or /merchants/1.json
   def destroy
-    @merchant.destroy
+    if current_user.role_admin?
+      @merchant.destroy
 
-    respond_to do |format|
-      format.html { redirect_to merchants_url, notice: 'Merchant was successfully destroyed.' }
-      format.json { head :no_content }
+      respond_to do |format|
+        format.html { redirect_to merchants_url, notice: 'Merchant was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    else
+      redirect_to merchants_url, alert: 'Admin not authrized'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,13 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def edit; end
+  def edit
+    if current_user.role_admin?
+      @user = User.find_by_id(params[:id])
+    else
+      redirect_to @user, alert: 'Admin not authrized'
+    end
+  end
 
   def create
     @user = User.new(user_params)
@@ -43,10 +49,14 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
-      format.json { head :no_content }
+    if current_user.role_admin?
+      @user.destroy
+      respond_to do |format|
+        format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    else
+      redirect_to users_url, alert: 'Admin not authrized'
     end
   end
 


### PR DESCRIPTION
Fixed the meaning of user roles.
Users can only view (Show) pages of users and merchants. Admins can edit and delete users and merchants.
This is an easy way, but not the best.
The better solution is to install the Pandit gem and use it to make settings.